### PR TITLE
feat: add configurable availability providers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "name": "Run npm dev",
             "request": "launch",
             "type": "node-terminal",
-            "envFile": "${workspaceFolder}/.env"
+            "envFile": "${workspaceFolder}/.env.local"
         },
     ]
 }

--- a/api/intentions/availability.intention.ts
+++ b/api/intentions/availability.intention.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import logger from '../../shared/logger';
 
 interface IntentionResult {
   intent: 'availability' | 'operating_hour' | 'book' | 'joke' | 'other';
@@ -79,12 +80,13 @@ export async function checkAvailabilityIntention(message: string): Promise<Inten
 
     const args = JSON.parse(functionCall.arguments);
 
+    logger.info({ ...args }, 'Intention result from OpenAI: %s', args.intent);
     return {
       intent: args.intent,
       ...(Object.keys(args).length > 0 && { details: { ...args } })
     };
   } catch (error) {
-    console.error('Error checking availability intention with OpenAI:', error);
+    logger.error(error, 'Error checking availability intention with OpenAI: %s', String(error));
     throw error
   }
 }

--- a/api/services/availability/availability.service.ts
+++ b/api/services/availability/availability.service.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import logger from '../../../shared/logger';
 
 interface AvailableCourt {
   date: string;
@@ -114,7 +115,7 @@ export class AvailabilityService {
     }
 
     async checkAvailability({ timeStart, timeEnd }: { timeStart: string, timeEnd: string }): Promise<ProviderSport[]> {
-
+        logger.info({ timeStart, timeEnd }, `[Supplier API] Checking availability for time range: ${timeStart} - ${timeEnd}`);
         try {
             const response = await fetch(`${this.apiBaseUrl}/${this.providerId}`, {
                 method: 'POST',
@@ -139,7 +140,7 @@ export class AvailabilityService {
             const data: ProviderSport[] = await response.json();
             return data;
         } catch (error) {
-            console.error('Error checking availability:', error);
+            logger.error(error, 'Error checking availability: %s', String(error));
             throw new Error('Failed to check availability. Please try again later.');
         }
     }
@@ -237,11 +238,13 @@ export class AvailabilityService {
             }
         });
 
+        logger.info(`[Supplier API] Availability Found ${result.length} available courts`);
         return result;
     }
 
     async getFormattedAvailability(estimateDate: EstAvailabilityDate, language: string = 'Thai'): Promise<string> {
         try {
+            logger.info({ ...estimateDate }, '[Supplier API] Formatting availability response')
             const rangeDate = this.getDates(estimateDate);
 
             const availability = await this.checkAvailability(rangeDate);
@@ -267,7 +270,7 @@ ${JSON.stringify(formattedData, null, 2)}`
 
             return completion.choices[0]?.message?.content || 'Availability information is not available.';
         } catch (error) {
-            console.error('Error getting formatted availability:', error);
+            logger.error(error, 'Error getting formatted availability: %s', String(error));
             return 'Sorry, we encountered an error while checking availability. Please try again later.';
         }
     }

--- a/api/services/availability/availability.supabase.service.ts
+++ b/api/services/availability/availability.supabase.service.ts
@@ -1,0 +1,217 @@
+import OpenAI from 'openai';
+import supabaseClient from '../../../shared/providers/supabase';
+
+interface AvailableCourt {
+  date: string;
+  availableCourts: Array<{
+    courtName: string;
+    availableSlots: Array<{
+      start: string;
+      end: string;
+    }>;
+  }>;
+}
+
+type EstAvailabilityDate = {
+    year?: number,
+    month?: number,
+    date?: number,
+    language?: string
+};
+
+export class SupabaseAvailabilityService {
+    private openai: OpenAI;
+
+    constructor() {
+        this.openai = new OpenAI({
+            apiKey: process.env.OPENAI_API_KEY,
+        });
+    }
+
+    private getDates(estimateDate: EstAvailabilityDate): { timeStart: string, timeEnd: string } {
+        const date = new Date();
+        const year = estimateDate.year ?? date.getFullYear();
+        const month = estimateDate.month ?? date.getMonth() + 1;
+        const day = estimateDate.date ?? 1;
+
+        date.setFullYear(year);
+        date.setMonth(month - 1);
+        date.setDate(day);
+
+        const timeStart = new Date(date);
+        const timeEnd = new Date(date);
+
+        if (estimateDate.date) {
+            // If a specific date is provided, fetch 4 days before and after that date
+            timeStart.setDate(day - 4);
+            timeEnd.setDate(day + 4);
+        } else {
+            // If only month is provided (no specific date), fetch the entire month
+            if (estimateDate.month) {
+                const firstDay = new Date(year, month - 1, 1);
+                const lastDay = new Date(year, month, 0); // last day of the month
+                return {
+                    timeStart: firstDay.toISOString().split('T')[0],
+                    timeEnd: lastDay.toISOString().split('T')[0],
+                };
+            } else {
+                // If both date and month are absent, fetch for 7 days from today
+                const today = new Date();
+                const sevenDaysLater = new Date();
+                sevenDaysLater.setDate(today.getDate() + 6); // 7-day window including today
+                return {
+                    timeStart: today.toISOString().split('T')[0],
+                    timeEnd: sevenDaysLater.toISOString().split('T')[0],
+                };
+            }
+        }
+
+        return {
+            timeStart: timeStart.toISOString().split('T')[0],
+            timeEnd: timeEnd.toISOString().split('T')[0],
+        };
+    }
+
+    private toSupabaseTs(dateStr: string, timeZone: string, endOfDay = false): string {
+        const time = endOfDay ? '23:59:59' : '00:00:00';
+        const d = new Date(`${dateStr}T${time}`);
+        const inv = new Date(d.toLocaleString('en-US', { timeZone }));
+        const diff = d.getTime() - inv.getTime();
+        return new Date(d.getTime() - diff).toISOString();
+    }
+
+    async checkAvailability({ timeStart, timeEnd }: { timeStart: string; timeEnd: string }): Promise<Map<string, Map<string, Array<{ start: string; end: string }>>>> {
+        const tenantId = process.env.BOOKING_TENANT_ID;
+        if (!tenantId) {
+            throw new Error('BOOKING_TENANT_ID env is required');
+        }
+
+        const { data: tenantCfg } = await supabaseClient
+            .from('tenant_configs')
+            .select('timezone')
+            .eq('tenant_id', tenantId)
+            .single();
+        const timeZone = tenantCfg?.timezone || 'UTC';
+
+        const { data: resources } = await supabaseClient
+            .schema('booking')
+            .from('resources')
+            .select('id, name, slot_granularity_minutes')
+            .eq('tenant_id', tenantId);
+
+        const dateToCourtVacantSlots = new Map<string, Map<string, Array<{ start: string; end: string }>>>();
+
+        for (const r of resources ?? []) {
+            const { data: slots, error } = await supabaseClient.rpc('find_slot_vacancy', {
+                tenant_id: tenantId,
+                resource_id: r.id,
+                t0: this.toSupabaseTs(timeStart, timeZone),
+                t1: this.toSupabaseTs(timeEnd, timeZone, true),
+                slot_mins: r.slot_granularity_minutes,
+            });
+
+            if (error || !slots) continue;
+
+            (slots as { slot_start: string; slot_end: string }[]).forEach((s) => {
+                const dateStr = new Date(s.slot_start).toLocaleDateString('en-CA', { timeZone });
+                const start = new Date(s.slot_start).toLocaleTimeString('en-GB', {
+                    timeZone,
+                    hour12: false,
+                    hour: '2-digit',
+                    minute: '2-digit',
+                });
+                const end = new Date(s.slot_end).toLocaleTimeString('en-GB', {
+                    timeZone,
+                    hour12: false,
+                    hour: '2-digit',
+                    minute: '2-digit',
+                });
+
+                if (!dateToCourtVacantSlots.has(dateStr)) {
+                    dateToCourtVacantSlots.set(dateStr, new Map());
+                }
+                const courtMap = dateToCourtVacantSlots.get(dateStr)!;
+                if (!courtMap.has(r.name)) {
+                    courtMap.set(r.name, []);
+                }
+                courtMap.get(r.name)!.push({ start, end });
+            });
+        }
+
+        return dateToCourtVacantSlots;
+    }
+
+    private transformAvailabilityData(
+        dateToCourtVacantSlots: Map<string, Map<string, Array<{ start: string; end: string }>>>,
+        estimateDate: EstAvailabilityDate,
+    ): AvailableCourt[] {
+        const result: AvailableCourt[] = [];
+
+        const sortedDates = Array.from(dateToCourtVacantSlots.entries()).sort(
+            ([dateA], [dateB]) => new Date(dateA).getTime() - new Date(dateB).getTime(),
+        );
+
+        const targetDate = new Date(
+            estimateDate.year ?? new Date().getFullYear(),
+            (estimateDate.month ?? new Date().getMonth() + 1) - 1,
+            estimateDate.date ?? 1,
+        );
+
+        const closestDates = sortedDates
+            .map(([date]) => ({ date, diff: Math.abs(new Date(date).getTime() - targetDate.getTime()) }))
+            .sort((a, b) => a.diff - b.diff)
+            .slice(0, 3)
+            .map((item) => item.date);
+
+        closestDates.forEach((date) => {
+            const courtMap = dateToCourtVacantSlots.get(date);
+            if (courtMap) {
+                const availableCourts = Array.from(courtMap.entries()).map(([courtName, slots]) => ({
+                    courtName,
+                    availableSlots: slots,
+                }));
+
+                if (availableCourts.length > 0) {
+                    result.push({
+                        date,
+                        availableCourts,
+                    });
+                }
+            }
+        });
+
+        return result;
+    }
+
+    async getFormattedAvailability(estimateDate: EstAvailabilityDate, language: string = 'Thai'): Promise<string> {
+        try {
+            const rangeDate = this.getDates(estimateDate);
+
+            const availability = await this.checkAvailability(rangeDate);
+            const formattedData = this.transformAvailabilityData(availability, estimateDate);
+
+            const completion = await this.openai.chat.completions.create({
+                model: 'gpt-5-mini',
+                messages: [
+                    {
+                        role: 'system',
+                        content: `You are a helpful assistant man that formats ski/snowboard slope availability information.
+                     Respond with a very short, clear, friendly message, with emoji in ${language} that summarizes the availability details. Start by telling about the range user requested date in ${language}. If no availability, encourage user to input some date`
+                    },
+                    {
+                        role: 'user',
+                        content: `These are the closest available slots to the requested date, please provide a summary in ${language}.
+Requested date context: ${JSON.stringify(rangeDate)}
+Availability (closest to the requested date):
+${JSON.stringify(formattedData, null, 2)}`
+                    }
+                ],
+            });
+
+            return completion.choices[0]?.message?.content || 'Availability information is not available.';
+        } catch (error) {
+            console.error('Error getting formatted availability:', error);
+            return 'Sorry, we encountered an error while checking availability. Please try again later.';
+        }
+    }
+}

--- a/api/services/availability/availability.supabase.service.ts
+++ b/api/services/availability/availability.supabase.service.ts
@@ -102,13 +102,16 @@ export class SupabaseAvailabilityService {
         const dateToCourtVacantSlots = new Map<string, Map<string, Array<{ start: string; end: string }>>>();
 
         for (const r of resources ?? []) {
-            const { data: slots, error } = await supabaseClient.rpc('find_slot_vacancy', {
-                tenant_id: tenantId,
-                resource_id: r.id,
-                t0: this.toSupabaseTs(timeStart, timeZone),
-                t1: this.toSupabaseTs(timeEnd, timeZone, true),
-                slot_mins: r.slot_granularity_minutes,
-            });
+            const { data: slots, error } = await supabaseClient.rpc(
+                'booking.get_free_slots',
+                {
+                    tenant_id: tenantId,
+                    resource_id: r.id,
+                    t0: this.toSupabaseTs(timeStart, timeZone),
+                    t1: this.toSupabaseTs(timeEnd, timeZone, true),
+                    slot_mins: r.slot_granularity_minutes,
+                },
+            );
 
             if (error || !slots) continue;
 

--- a/api/services/availability/availability.supabase.service.ts
+++ b/api/services/availability/availability.supabase.service.ts
@@ -102,14 +102,14 @@ export class SupabaseAvailabilityService {
         const dateToCourtVacantSlots = new Map<string, Map<string, Array<{ start: string; end: string }>>>();
 
         for (const r of resources ?? []) {
-            const { data: slots, error } = await supabaseClient.rpc(
-                'booking.get_free_slots',
-                {
-                    tenant_id: tenantId,
-                    resource_id: r.id,
-                    t0: this.toSupabaseTs(timeStart, timeZone),
-                    t1: this.toSupabaseTs(timeEnd, timeZone, true),
-                    slot_mins: r.slot_granularity_minutes,
+            const { data: slots, error } = await supabaseClient
+            .schema('booking')
+            .rpc('get_free_slots', {
+                    p_tenant_id: tenantId,
+                    p_resource_id: r.id,
+                    p_t0: this.toSupabaseTs(timeStart, timeZone),
+                    p_t1: this.toSupabaseTs(timeEnd, timeZone, true),
+                    p_slot_mins: r.slot_granularity_minutes,
                 },
             );
 

--- a/api/services/availability/index.ts
+++ b/api/services/availability/index.ts
@@ -2,4 +2,4 @@ import { AvailabilityService as ApiAvailabilityService } from './availability.se
 import { SupabaseAvailabilityService } from './availability.supabase.service';
 
 const source = process.env.AVAILABILITY_SOURCE;
-export const AvailabilityService = source === 'supabase' ? SupabaseAvailabilityService : ApiAvailabilityService;
+export const AvailabilityService = source === 'supplier_api' ? ApiAvailabilityService : SupabaseAvailabilityService;

--- a/api/services/availability/index.ts
+++ b/api/services/availability/index.ts
@@ -1,0 +1,5 @@
+import { AvailabilityService as ApiAvailabilityService } from './availability.service';
+import { SupabaseAvailabilityService } from './availability.supabase.service';
+
+const source = process.env.AVAILABILITY_SOURCE;
+export const AvailabilityService = source === 'supabase' ? SupabaseAvailabilityService : ApiAvailabilityService;

--- a/api/services/line/line.handler.ts
+++ b/api/services/line/line.handler.ts
@@ -1,6 +1,7 @@
 import { ILineMessageHandler } from '../../interfaces/line.interface';
 import * as line from '@line/bot-sdk';
 import fetch from 'node-fetch';
+import logger from '../../../shared/logger';
 
 export class LineMessageHandler implements ILineMessageHandler {
   async handleMessage(event: line.MessageEvent): Promise<void> {
@@ -10,7 +11,7 @@ export class LineMessageHandler implements ILineMessageHandler {
 
     const forwardUrl = process.env.FORWARD_URL;
     if (!forwardUrl) {
-      console.error('FORWARD_URL is not set in environment variables');
+      logger.error('FORWARD_URL is not set in environment variables');
       return;
     }
 
@@ -29,28 +30,28 @@ export class LineMessageHandler implements ILineMessageHandler {
         }),
       });
     } catch (error) {
-      console.error('Error forwarding message:', error);
+      logger.error(error, 'Error forwarding message: %s', String(error));
       throw error;
     }
   }
 
   async handleFollow(event: line.FollowEvent): Promise<void> {
-    console.log('Received follow event:', event);
+    logger.info('Received follow event: %s', event);
     // Handle follow event if needed
   }
 
   async handleUnfollow(event: line.UnfollowEvent): Promise<void> {
-    console.log('Received unfollow event:', event);
+    logger.info('Received unfollow event: %s', event);
     // Handle unfollow event if needed
   }
 
   async handlePostback(event: line.PostbackEvent): Promise<void> {
-    console.log('Received postback event:', event);
+    logger.info('Received postback event: %s', event);
     // Handle postback event if needed
   }
 
   async handleError(error: Error): Promise<void> {
-    console.error('Error in LINE message handler:', error);
+    logger.error(error, 'Error in LINE message handler: %s', String(error));
     // Additional error handling logic can be added here
   }
 }

--- a/api/services/line/line.service.ts
+++ b/api/services/line/line.service.ts
@@ -50,7 +50,7 @@ export class LineService implements ILineService {
       case 'postback':
         return this.handler.handlePostback(event as PostbackEvent);
       default:
-        console.log(`Unhandled event type: ${event.type}`);
+        logger.info(`Unhandled event type: ${event.type}`);
     }
   }
 }

--- a/api/webhooks/webhook.ts
+++ b/api/webhooks/webhook.ts
@@ -4,7 +4,7 @@ import { LineService } from '../services/line/line.service';
 import { LineMessageHandler } from '../services/line/line.handler';
 import { ILineConfig } from '../interfaces/line.interface';
 import { checkAvailabilityIntention } from '../intentions';
-import { AvailabilityService } from '../services/availability/availability.service';
+import { AvailabilityService } from '../services/availability';
 import OpenAI from 'openai';
 
 // LINE client configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "pino-pretty": "^13.1.1"
       },
       "devDependencies": {
-        "@kaojai-ai/db-schema": "^0.1.2",
+        "@kaojai-ai/db-schema": "^0.1.18",
         "@swc/core": "^1.13.5",
         "@swc/jest": "^0.2.39",
         "@types/express": "^4.17.21",
@@ -1686,9 +1686,9 @@
       }
     },
     "node_modules/@kaojai-ai/db-schema": {
-      "version": "0.1.17",
-      "resolved": "https://npm.pkg.github.com/download/@kaojai-ai/db-schema/0.1.17/22b75966bc7896dfc7d5b7c37544b6dee9a7cd6c",
-      "integrity": "sha512-Senmy5hY14djmVw6HT63sAte+xDi2FJgMmBip4F5E9FamvJSt4u5p4GBM7VXhAlGXSkEmON9jj/MviTAx3BUyA==",
+      "version": "0.1.18",
+      "resolved": "https://npm.pkg.github.com/download/@kaojai-ai/db-schema/0.1.18/5d67500bf1fa105bb69630c68453fb916c4b9089",
+      "integrity": "sha512-Bt+JR4vZ4FOx5fZtHPlMHS6XSGZH6pIQ4NtnS6kw917ACIJfGi2fDluGCuajm9w+2F5xEbE7EH/H00eV7U6M/g==",
       "dev": true,
       "license": "UNLICENSE"
     },

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
   },
   "dependencies": {
     "@line/bot-sdk": "^10.1.2",
-    "body-parser": "^1.20.2",
-    "express": "^4.18.2",
-    "node-fetch": "^2.7.0",
-    "openai": "^5.12.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.57.2",
     "@opentelemetry/auto-instrumentations-node": "^0.55.3",
@@ -22,12 +18,16 @@
     "@opentelemetry/sdk-logs": "^0.57.2",
     "@opentelemetry/sdk-metrics": "^1.30.1",
     "@supabase/supabase-js": "^2.45.0",
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2",
+    "node-fetch": "^2.7.0",
+    "openai": "^5.12.2",
     "pino": "^9.9.1",
     "pino-loki": "^2.6.0",
     "pino-pretty": "^13.1.1"
   },
   "devDependencies": {
-    "@kaojai-ai/db-schema": "^0.1.2",
+    "@kaojai-ai/db-schema": "^0.1.18",
     "@swc/core": "^1.13.5",
     "@swc/jest": "^0.2.39",
     "@types/express": "^4.17.21",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,13 @@
     "target": "ES2020",
     "module": "commonjs",
     "outDir": "dist",
-    "rootDir": "api",
+    "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true
   },
-  "include": ["api/**/*"],
+  "include": ["api/**/*", "shared/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- restore legacy API-based availability service alongside new Supabase service
- switch providers via `AVAILABILITY_SOURCE` environment variable

## Testing
- `npx eslint .` (fails: ESLint couldn't find config)
- `npm run build` (fails: missing type definitions)


------
https://chatgpt.com/codex/tasks/task_e_68c4fcedbc00832c83ad0d3b70b0bf3a