### PR TITLE
Add dynamic operating hours response

### DIFF
--- a/api/services/operating-hours/index.ts
+++ b/api/services/operating-hours/index.ts
@@ -1,0 +1,1 @@
+export * from './operating-hours.service';

--- a/api/services/operating-hours/operating-hours.service.ts
+++ b/api/services/operating-hours/operating-hours.service.ts
@@ -1,18 +1,6 @@
 import supabaseClient from '../../../shared/providers/supabase';
 import logger from '../../../shared/logger';
 
-interface OperatingHour {
-  day_of_week: number;
-  open_time: string;
-  close_time: string;
-}
-
-interface Closure {
-  start_time: string;
-  end_time: string;
-  title?: string;
-}
-
 export class OperatingHoursService {
   async getOperatingHoursMessage(): Promise<string> {
     const tenantId = process.env.BOOKING_TENANT_ID;
@@ -22,8 +10,8 @@ export class OperatingHoursService {
 
     const { data: operatingHours, error: opErr } = await supabaseClient
       .schema('booking')
-      .from('tenant_operating_hour')
-      .select('day_of_week, open_time, close_time')
+      .from('tenant_operating_hours')
+      .select('*')
       .eq('tenant_id', tenantId);
 
     if (opErr) {
@@ -34,13 +22,15 @@ export class OperatingHoursService {
     const next30 = new Date();
     next30.setDate(now.getDate() + 30);
 
+    // Postgres range literal: lower-inclusive, upper-exclusive
+    const windowRange = `[${now.toISOString()},${next30.toISOString()})`;
+
     const { data: closures, error: clErr } = await supabaseClient
       .schema('booking')
       .from('closures')
-      .select('start_time, end_time, title')
+      .select('*')
       .eq('tenant_id', tenantId)
-      .gte('start_time', now.toISOString())
-      .lte('start_time', next30.toISOString());
+      .filter('closed_during', 'ov', windowRange); // overlaps
 
     if (clErr) {
       logger.error(clErr, 'Error fetching closures: %s', String(clErr));
@@ -49,16 +39,27 @@ export class OperatingHoursService {
     const dayNames = ['วันอาทิตย์', 'วันจันทร์', 'วันอังคาร', 'วันพุธ', 'วันพฤหัสบดี', 'วันศุกร์', 'วันเสาร์'];
 
     const lines = (operatingHours || [])
-      .map((oh: OperatingHour) => `${dayNames[oh.day_of_week]}: ${oh.open_time} - ${oh.close_time}`)
+      .map((oh) => `${dayNames[oh.weekday]}: ${oh.open_time} - ${oh.close_time}`)
       .join('\n');
 
+    // TODO load from db
+    const tenantTZ = process.env.BOOKING_TENANT_TIMEZONE || 'Asia/Bangkok';
+
     let closureLines = '';
+
     if (closures && closures.length > 0) {
       closureLines = closures
-        .map((c: Closure) => {
-          const start = new Date(c.start_time).toLocaleDateString('th-TH');
-          const end = new Date(c.end_time).toLocaleDateString('th-TH');
-          return `${start}${start !== end ? ` ถึง ${end}` : ''}${c.title ? ` (${c.title})` : ''}`;
+        .map((c) => {
+          const { start, end } = parsePgTstzRange(c.closed_during as string);
+
+          const startStr = start ? fmtInTZ(start, tenantTZ) : 'ไม่ระบุเริ่มต้น';
+          const endStr = end ? fmtInTZ(end, tenantTZ) : 'ไม่ระบุสิ้นสุด';
+
+          const same = start && end ? sameMinute(start, end) : false;
+          const rangePart = same ? `${startStr}` : `${startStr} ถึง ${endStr}`;
+          const titlePart = c.reason ? ` (${c.reason})` : '';
+
+          return `${rangePart}${titlePart}`;
         })
         .join('\n');
     } else {

--- a/api/services/operating-hours/operating-hours.service.ts
+++ b/api/services/operating-hours/operating-hours.service.ts
@@ -1,0 +1,70 @@
+import supabaseClient from '../../../shared/providers/supabase';
+import logger from '../../../shared/logger';
+
+interface OperatingHour {
+  day_of_week: number;
+  open_time: string;
+  close_time: string;
+}
+
+interface Closure {
+  start_time: string;
+  end_time: string;
+  title?: string;
+}
+
+export class OperatingHoursService {
+  async getOperatingHoursMessage(): Promise<string> {
+    const tenantId = process.env.BOOKING_TENANT_ID;
+    if (!tenantId) {
+      throw new Error('BOOKING_TENANT_ID env is required');
+    }
+
+    const { data: operatingHours, error: opErr } = await supabaseClient
+      .schema('booking')
+      .from('tenant_operating_hour')
+      .select('day_of_week, open_time, close_time')
+      .eq('tenant_id', tenantId);
+
+    if (opErr) {
+      logger.error(opErr, 'Error fetching operating hours: %s', String(opErr));
+    }
+
+    const now = new Date();
+    const next30 = new Date();
+    next30.setDate(now.getDate() + 30);
+
+    const { data: closures, error: clErr } = await supabaseClient
+      .schema('booking')
+      .from('closures')
+      .select('start_time, end_time, title')
+      .eq('tenant_id', tenantId)
+      .gte('start_time', now.toISOString())
+      .lte('start_time', next30.toISOString());
+
+    if (clErr) {
+      logger.error(clErr, 'Error fetching closures: %s', String(clErr));
+    }
+
+    const dayNames = ['วันอาทิตย์', 'วันจันทร์', 'วันอังคาร', 'วันพุธ', 'วันพฤหัสบดี', 'วันศุกร์', 'วันเสาร์'];
+
+    const lines = (operatingHours || [])
+      .map((oh: OperatingHour) => `${dayNames[oh.day_of_week]}: ${oh.open_time} - ${oh.close_time}`)
+      .join('\n');
+
+    let closureLines = '';
+    if (closures && closures.length > 0) {
+      closureLines = closures
+        .map((c: Closure) => {
+          const start = new Date(c.start_time).toLocaleDateString('th-TH');
+          const end = new Date(c.end_time).toLocaleDateString('th-TH');
+          return `${start}${start !== end ? ` ถึง ${end}` : ''}${c.title ? ` (${c.title})` : ''}`;
+        })
+        .join('\n');
+    } else {
+      closureLines = 'ไม่มีการปิดให้บริการใน 30 วันข้างหน้า';
+    }
+
+    return `เวลาเปิดให้บริการ\n${lines}\n\nกำหนดการปิดให้บริการ\n${closureLines}`;
+  }
+}

--- a/shared/utils/dateHelper.ts
+++ b/shared/utils/dateHelper.ts
@@ -1,0 +1,35 @@
+// Helpers
+const parsePgTstzRange = (range: string) => {
+    // Examples: [2025-09-13 10:00+07,2025-09-13 12:00+07)
+    //           ["2025-09-13 10:00+07","2025-09-13 12:00+07")
+    const lowerInc = range.startsWith('[');
+    const upperInc = range.endsWith(']');
+
+    const inner = range.slice(1, -1).trim();           // strip [ ), etc.
+    // safe split—ISO timestamps won’t contain commas
+    let [a, b] = inner.split(',');
+    a = (a || '').trim().replace(/^"+|"+$/g, '');
+    b = (b || '').trim().replace(/^"+|"+$/g, '');
+
+    // open bounds come back as empty string
+    const start = a ? new Date(a) : null;
+    const endRaw = b ? new Date(b) : null;
+
+    // Postgres ranges are usually upper-exclusive ')'
+    // For display, keep as-is; if you want inclusive feel, subtract 1ms:
+    const end = endRaw && !upperInc ? endRaw : endRaw;
+
+    return { start, end, lowerInc, upperInc };
+};
+
+const fmtInTZ = (d: Date, tz: string) =>
+    new Intl.DateTimeFormat('th-TH', {
+        timeZone: tz, dateStyle: 'medium', timeStyle: 'short'
+    }).format(d);
+
+const sameMinute = (a: Date, b: Date) =>
+    a.getUTCFullYear() === b.getUTCFullYear() &&
+    a.getUTCMonth() === b.getUTCMonth() &&
+    a.getUTCDate() === b.getUTCDate() &&
+    a.getUTCHours() === b.getUTCHours() &&
+    a.getUTCMinutes() === b.getUTCMinutes();


### PR DESCRIPTION
## Summary
- add OperatingHoursService to query tenant operating hours and upcoming closures from Supabase
- reply with formatted Thai message for operating hour intent in webhook

## Testing
- `npx eslint .` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c564743848832cb47fac02be1dce0c