### PR TITLE
feat: show availability carousel

### DIFF
--- a/api/services/availability/availability.service.ts
+++ b/api/services/availability/availability.service.ts
@@ -1,16 +1,6 @@
 import OpenAI from 'openai';
 import logger from '../../../shared/logger';
-
-interface AvailableCourt {
-  date: string;
-  availableCourts: Array<{
-    courtName: string;
-    availableSlots: Array<{
-      start: string;
-      end: string;
-    }>;
-  }>;
-}
+import type { AvailabilityByDate, AvailabilityOverview, EstAvailabilityDate } from './types';
 
 interface CourtMatch {
     id: number;
@@ -49,13 +39,6 @@ interface ProviderSport {
     sport: Sport;
     courts: Court[];
 }
-
-type EstAvailabilityDate = {
-    year?: number,
-    month?: number,
-    date?: number,
-    language?: string
-};
 
 export class AvailabilityService {
     private openai: OpenAI;
@@ -168,8 +151,8 @@ export class AvailabilityService {
         }
     }
 
-    private transformAvailabilityData(availability: ProviderSport[], estimateDate: EstAvailabilityDate): AvailableCourt[] {
-        const result: AvailableCourt[] = [];
+    private transformAvailabilityData(availability: ProviderSport[], estimateDate: EstAvailabilityDate): AvailabilityByDate[] {
+        const result: AvailabilityByDate[] = [];
         // Map<DateString, Map<CourtName, Array<{start: string, end: string}>>>
         const dateToCourtVacantSlots = new Map<string, Map<string, Array<{ start: string; end: string }>>>();
 
@@ -265,40 +248,66 @@ export class AvailabilityService {
         return result;
     }
 
-    async getFormattedAvailability(estimateDate: EstAvailabilityDate, language: string = 'Thai'): Promise<string> {
+    async getAvailabilityOverview(
+        estimateDate: EstAvailabilityDate,
+        language: string = 'Thai',
+    ): Promise<AvailabilityOverview> {
+        logger.info({ ...estimateDate }, '[Supplier API] Formatting availability response');
+
+        if (this.isPastDate(estimateDate)) {
+            return {
+                summary: 'The requested date is already in the past.',
+                availabilityByDate: [],
+            };
+        }
+
+        const rangeDate = this.getDates(estimateDate);
+
         try {
-            logger.info({ ...estimateDate }, '[Supplier API] Formatting availability response')
-            if (this.isPastDate(estimateDate)) {
-                return 'The requested date is already in the past.';
-            }
-
-            const rangeDate = this.getDates(estimateDate);
-
             const availability = await this.checkAvailability(rangeDate);
             const formattedData = this.transformAvailabilityData(availability, estimateDate);
 
-            const completion = await this.openai.chat.completions.create({
-                model: 'gpt-5-mini',
-                messages: [
-                    {
-                        role: 'system',
-                        content: `You are a helpful assistant man that formats ski/snowboard slope availability information.
-                     Respond with a very short, clear, friendly message, with emoji in ${language} that summarizes the availability details. Start by telling about the range user requested date in ${language}. If no availability, encourage user to input some date`
-                    },
-                    {
-                        role: 'user',
-                        content: `These are the closest available slots to the requested date, please provide a summary in ${language}.
+            let summary = 'Availability information is not available.';
+
+            try {
+                const completion = await this.openai.chat.completions.create({
+                    model: 'gpt-5-mini',
+                    messages: [
+                        {
+                            role: 'system',
+                            content: `You are a helpful assistant man that formats ski/snowboard slope availability information. 
+                     Respond with a very short, clear, friendly message, with emoji in ${language} that summarizes the availability details. Start by telling about the range user requested date in ${language}. If no availability, encourage user to input some date`,
+                        },
+                        {
+                            role: 'user',
+                            content: `These are the closest available slots to the requested date, please provide a summary in ${language}.
 Requested date context: ${JSON.stringify(rangeDate)}
 Availability (closest to the requested date):
-${JSON.stringify(formattedData, null, 2)}`
-                    }
-                ],
-            });
+${JSON.stringify(formattedData, null, 2)}`,
+                        },
+                    ],
+                });
 
-            return completion.choices[0]?.message?.content || 'Availability information is not available.';
+                summary = completion.choices[0]?.message?.content || summary;
+            } catch (error) {
+                logger.error(error, 'Error generating availability summary: %s', String(error));
+            }
+
+            return {
+                summary,
+                availabilityByDate: formattedData,
+            };
         } catch (error) {
-            logger.error(error, 'Error getting formatted availability: %s', String(error));
-            return 'Sorry, we encountered an error while checking availability. Please try again later.';
+            logger.error(error, 'Error getting availability overview: %s', String(error));
+            return {
+                summary: 'Sorry, we encountered an error while checking availability. Please try again later.',
+                availabilityByDate: [],
+            };
         }
+    }
+
+    async getFormattedAvailability(estimateDate: EstAvailabilityDate, language: string = 'Thai'): Promise<string> {
+        const overview = await this.getAvailabilityOverview(estimateDate, language);
+        return overview.summary;
     }
 }

--- a/api/services/availability/types.ts
+++ b/api/services/availability/types.ts
@@ -1,0 +1,26 @@
+export interface EstAvailabilityDate {
+  year?: number;
+  month?: number;
+  date?: number;
+  language?: string;
+}
+
+export interface AvailableSlot {
+  start: string;
+  end: string;
+}
+
+export interface AvailableCourtAvailability {
+  courtName: string;
+  availableSlots: AvailableSlot[];
+}
+
+export interface AvailabilityByDate {
+  date: string;
+  availableCourts: AvailableCourtAvailability[];
+}
+
+export interface AvailabilityOverview {
+  summary: string;
+  availabilityByDate: AvailabilityByDate[];
+}


### PR DESCRIPTION
## Summary
- add shared availability availability types and expose a getAvailabilityOverview helper in both availability services
- respond to availability intents with a LINE carousel highlighting up to five days of available slots while still sending the summary text
- provide graceful fallbacks when no availability exists or when summaries are unavailable

## Testing
- npm run build *(fails: repository is missing type definitions for several dependencies)*
- npx eslint . *(fails: ESLint configuration file is not present)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cc43ba8c832c965d797da7c37085