### PR TITLE
Send getting started carousel on follow and menu

### DIFF
--- a/api/actions/getting-started.action.ts
+++ b/api/actions/getting-started.action.ts
@@ -3,10 +3,27 @@ import { LineService } from '../services/line/line.service';
 
 const gettingStartedCarousel: line.TemplateMessage = {
   type: 'template',
-  altText: 'เมนูช่วยเหลือน้องเข้าใจ',
+  altText: 'เริ่มต้นใช้งาน น้องเข้าใจ 💚',
   template: {
     type: 'carousel',
     columns: [
+      {
+        title: 'น้องเข้าใจ ทำอะไรได้บ้าง?',
+        thumbnailImageUrl: 'https://kaojai.ai/images/generic_landscape_1.png',
+        text: 'สวัสดี 👋, น้องเข้าใจ 💚 AI ChatBot 🤖 ยินดีช่วยเหลือธุรกิจร้านค้า และน้องเก่งมากๆ มารู้จักน้องกันเถอะ 🥰',
+        actions: [
+          {
+            type: 'message',
+            label: 'น้องทำอะไรได้บ้าง?',
+            text: 'KaoJai ทำอะไรได้บ้าง',
+          },
+          {
+            type: 'message',
+            label: 'ติดต่อ ทีมงาน',
+            text: 'ติดต่อ',
+          }
+        ],
+      },
       {
         title: 'รับแจ้งเตือน CheckSlip',
         thumbnailImageUrl: 'https://checkslip.kaojai.ai/images/blogs/danger-of-fake-slips.png',
@@ -36,8 +53,8 @@ const gettingStartedCarousel: line.TemplateMessage = {
           },
           {
             type: 'message',
-            label: 'ติดต่อทางโทรศัพท์',
-            text: 'ติดต่อทางโทรศัพท์',
+            label: 'ติดต่อ ทีมงาน',
+            text: 'ติดต่อ',
           }
         ],
       },

--- a/api/intents/getting-started.intent.ts
+++ b/api/intents/getting-started.intent.ts
@@ -14,5 +14,7 @@ export const isGettingStartedIntent = (event: line.MessageEvent): boolean => {
 
   const isMentioningSelf = normalizedMentionees.some((mention) => mention.type === 'user' && mention.isSelf) ?? false;
 
-  return isMentioningSelf || normalizedText === 'kj';
+  const triggers = ['kj', 'menu'];
+
+  return isMentioningSelf || triggers.includes(normalizedText);
 };

--- a/api/webhooks/webhook.ts
+++ b/api/webhooks/webhook.ts
@@ -41,8 +41,22 @@ export const createWebhook = (port: number = 3000): Application => {
             continue;
           }
 
+          if (event.type === 'follow') {
+            const followEvent = event as line.FollowEvent;
+
+            logger.info('Received follow event for user: %s', followEvent.source.userId);
+
+            if (followEvent.replyToken) {
+              await sendGettingStartedCarousel(lineService, followEvent.replyToken);
+            } else {
+              logger.warn('Missing reply token for follow event');
+            }
+
+            continue;
+          }
+
           if (event.type !== 'message') {
-            logger.info("Event type is not message");
+            logger.info({ type: event.type }, 'Unsupported event type');
             continue;
           }
 


### PR DESCRIPTION
## Summary
- send the getting started carousel when a user follows the LINE bot
- recognise the "menu" keyword as a getting started intent
- log unsupported event types more clearly

## Testing
- npx --yes eslint@9 .

------
https://chatgpt.com/codex/tasks/task_e_68cc1ddb8394832c916408b883509663